### PR TITLE
Better development logging

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -1,3 +1,11 @@
+function isException(data) {
+  return data.message && data.message.indexOf('uncaughtException') === 0;
+}
+
+function isProduction() {
+  return process.env.NODE_ENV === 'production'; // eslint-disable-line no-process-env
+}
+
 module.exports = function (namespace, data) {
   var out = [
     data.timestamp(),
@@ -6,8 +14,14 @@ module.exports = function (namespace, data) {
   ];
 
   if (data.message) out.push(data.message);
+
   if (data.meta && Object.keys(data.meta).length) {
     out.push(JSON.stringify(data.meta));
+  }
+
+  if (isException(data) && !isProduction()) {
+    out.push('\n');
+    out.push(data.meta.stack.join('\n'));
   }
 
   return out.join(' ');


### PR DESCRIPTION
Now outputs the stack trace when not in production so reading error messages is much easier.

Closes #9 
